### PR TITLE
Fix typo: esp_format -> resp_format

### DIFF
--- a/mppsolar/protocols/protocol.py
+++ b/mppsolar/protocols/protocol.py
@@ -170,7 +170,7 @@ class AbstractProtocol(metaclass=abc.ABCMeta):
                     else:
                         # output[resp_format[2][item]['name']] = status
                         # _key = "{}".format(resp_format[2][item]["name"]).lower().replace(" ", "_")
-                        _key = esp_format[2][item]["name"]
+                        _key = resp_format[2][item]["name"]
                         msgs[_key] = [status, ""]
                 # msgs[key] = [output, '']
             elif command_defn["type"] == "SETTER":


### PR DESCRIPTION
Fixes the following error:

Traceback ...
File "...src/mpp-solar/mppsolar/protocols/protocol.py", line 173, in decode
NameError: name 'esp_format' is not defined